### PR TITLE
Added List Hosts By Vuln Title Regex

### DIFF
--- a/list_hosts_by_vulnerability_title_regex.js
+++ b/list_hosts_by_vulnerability_title_regex.js
@@ -1,0 +1,26 @@
+var listHostsByVulnerabilityTitleRegex = function(vulnerabilityRegex) {
+  // Retrieves all host, port, protocol instances afflicted by a certain vulnerability
+  //
+  // Created by: Isaiah Sarju
+  // Based on listHostsByVulnerabilityTitle Dan Kottmann & updated by Alex Lauerman
+  // Usage: listHostsByVulnerabilityTitleRegex(/^SSL.*/);
+  // Requires client-side updates: false
+
+  var REGEX = vulnerabilityRegex;
+  var PROJECT_ID = Session.get('projectId');
+  var vulnerabilities = Vulnerabilities.find({"project_id": PROJECT_ID, "title": {"$regex": REGEX}}).fetch();
+  var msfHostsOutput = "";
+  if (!vulnerabilities) {
+    console.log("No vulnerabilities found");
+  } else {
+    vulnerabilities.forEach(function(vulnerability){
+        var hosts = vulnerability.hosts;
+        hosts.forEach(function(host){
+          console.log(host.string_addr + ":" + host.port + "/" + host.protocol);
+          msfHostsOutput += host.string_addr + ", ";
+        });
+        //This outputs the hosts in metasploit hosts format.  Comment this out if you dont want it.
+        console.log("RHOSTS: " + msfHostsOutput.slice(0, -2));
+      });
+  }
+};


### PR DESCRIPTION
list_hosts_by_vulnerability_title_regex.js
This allows you to list hosts by searching for vulns using regex such as listHostsByVulnerabilityTitleRegex(/^SSL.*/)