### PR TITLE
Fixed listUnknownOpenServices function

### DIFF
--- a/list_unknown_open_services.js
+++ b/list_unknown_open_services.js
@@ -36,7 +36,7 @@ function listUnknownOpenServices (scope, outputFormat) {
     services.forEach(function (service) {
       if (service.port > 0) {
         if (scope === 'product') {
-          if (service.product === 'unknown') {
+          if (service.product.toLowerCase() === 'unknown') {
             hostlist.push(host.ipv4)
             if (service.protocol === 'tcp') {
               tcpservices.push(service.port)
@@ -45,7 +45,7 @@ function listUnknownOpenServices (scope, outputFormat) {
             }
           }
         } else if (scope === 'service') {
-          if (service.port === 'unknown') {
+          if (service.service.toLowerCase() === 'unknown') {
             hostlist.push(host.ipv4)
             if (service.protocol === 'tcp') {
               tcpservices.push(service.port)
@@ -54,7 +54,7 @@ function listUnknownOpenServices (scope, outputFormat) {
             }
           }
         } else if (scope === 'both') {
-          if (service.port === 'unknown' || service.product === 'unknown') {
+          if (service.service.toLowerCase() === 'unknown' || service.product.toLowerCase() === 'unknown') {
             hostlist.push(host.ipv4)
             if (service.protocol === 'tcp') {
               tcpservices.push(service.port)


### PR DESCRIPTION
The listUnknownOpenServices function did not correctly handle
capitalization of Unknown.

The test of unknown service was changed from service.port === 'unknown'
to service.service === 'unknown'